### PR TITLE
fix(ecs): create instances got error no attribute group

### DIFF
--- a/lib/ansible/modules/cloud/alicloud/ali_instance.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance.py
@@ -791,7 +791,7 @@ def main():
                     instances.pop(len(instances) - 1)
             else:
                 try:
-                    if re.search("-\[\d+,\d+\]-", host_name).group():
+                    if re.search("-\[\d+,\d+\]-", host_name):
                         module.fail_json(msg='Ordered hostname is not supported, If you want to add an ordered suffix to the hostname, you can set unique_suffix to True')
                     new_instances = run_instance(module, ecs, count - len(instances))
                     if new_instances:


### PR DESCRIPTION
fix bug,  Create new instances got an error: 'NoneType' object has no attribute 'group'"}
