### PR TITLE
feat: Freely combine multiple ecs server attributes as an inventory_name.

### DIFF
--- a/contrib/inventory/alicloud.ini
+++ b/contrib/inventory/alicloud.ini
@@ -29,6 +29,9 @@ destination_variable = public_ip_address
 # will still use destination_variable.
 # WARNING: ECS server attribute 'tags' should be written as 'tag_TAGNAME',
 #           E.g. hostname_variable = tag_my-ansible
+# You can also freely combine multiple ecs server attributes as an inventory_name.
+# They will be safely combined in sequence by the character "_".
+#           E.g. hostname_variable = [instance_id, instance_name, ...]
 hostname_variable = instance_id
 
 

--- a/contrib/inventory/alicloud.py
+++ b/contrib/inventory/alicloud.py
@@ -350,11 +350,16 @@ class EcsInventory(object):
 
         # Set the inventory name
         hostname = None
-        if self.hostname_variable:
-            if self.hostname_variable.startswith('tag_'):
-                hostname = instance.tags.get(self.hostname_variable[4:], None)
-            else:
-                hostname = getattr(instance, self.hostname_variable)
+        if isinstance(self.hostname_variable, (str, list)):
+            hostname_variable_compositions = []
+            if isinstance(self.hostname_variable, str):
+                self.hostname_variable = self.hostname_variable.split()
+            for hostname_variable_composition in self.hostname_variable:
+                if hostname_variable_composition.startswith('tag_'):
+                    hostname_variable_compositions.append(instance.tags.get(hostname_variable_composition[4:], None))
+                else:
+                    hostname_variable_compositions.append(getattr(instance, hostname_variable_composition))
+            hostname = "_".join(hostname_variable_compositions)
 
         # If we can't get a nice hostname, use the destination address
         if not hostname:


### PR DESCRIPTION

```ini
You can also freely combine multiple ecs server attributes as an inventory_name.
They will be safely combined in sequence by the character "_".
E.g. hostname_variable = [instance_id, instance_name, ...]
````
It will look like this =>

alicloud.ini:
```ini
hostname_variable = [instance_id, instance_name]
```

./alicloud.py --list
```json
{
  "_meta": {
    "hostvars": {
      "i_bp12cvmxv2xxxxxxxxxx_nginx001": {
	...
      },
      "i_bp12cvmxv2xxxxxxxxxx_nginx002": {
	...
      }
      ...
    }
    ...
  }
  ...
}
```