### PR TITLE
feat: enhance ali_disk tags and disk management

### DIFF
--- a/plugins/examples/alicloud-ecs-vpc/group_vars/all
+++ b/plugins/examples/alicloud-ecs-vpc/group_vars/all
@@ -72,5 +72,7 @@ disk_name: "Ansible_Disk"
 disk_category: "cloud_ssd"
 disk_description: "Create a new ECS disk resource via Ansible example alicloud-ecs-vpc."
 data_disk_size: 80
-disk_tags: [{tag_key: "created_by", tag_value: "Ansible-Alicloud"}, {tag_key: "created_from", tag_value: "example-alicloud-ecs-vpc"}]
+disk_tags:
+  created_by: "Ansible-Alicloud"
+  created_from: "example-alicloud-ecs-vpc"
 delete_with_instance: False

--- a/plugins/modules/ali_disk.py
+++ b/plugins/modules/ali_disk.py
@@ -26,8 +26,9 @@ options:
     type: str
   alicloud_zone:
     description:
-      - Aliyun availability zone ID which to launch the disk.
-    required: true
+      - Aliyun availability zone ID in which to launch the disk.
+      - Required when creating a disk except an ESSD regional disk
+        (C(cloud_regional_disk_auto)).
     aliases: ['zone_id', 'zone']
     type: str
   disk_name:
@@ -52,7 +53,7 @@ options:
       - The category to apply to the disk.
     default: 'cloud'
     aliases: ['volume_type', 'disk_type']
-    choices: ['cloud', 'cloud_efficiency', 'cloud_ssd', 'cloud_essd']
+    choices: ['cloud', 'cloud_efficiency', 'cloud_ssd', 'cloud_essd', 'cloud_auto', 'cloud_essd_entry', 'cloud_regional_disk_auto', 'elastic_ephemeral_disk_standard', 'elastic_ephemeral_disk_premium']
     type: str
   size:
     description:
@@ -68,11 +69,54 @@ options:
     type: str
   disk_tags:
     description:
-      - A list of hash/dictionaries of instance tags, ['{"tag_key":"value", "tag_value":"value"}'],
-        tag_key must be not null when tag_value isn't null.
+      - A dictionary of tags to apply to the disk. C({"key":"value"}).
     aliases: ['tags']
-    type: list
-    elements: dict
+    type: dict
+  purge_tags:
+    description:
+      - Remove disk tags that are not declared in C(disk_tags).
+      - When C(true), specify every tag that should remain on the disk.
+    default: false
+    type: bool
+  bursting_enabled:
+    description:
+      - Whether burst performance is enabled for a supported disk.
+      - When specified for an existing disk, updates C(BurstingEnabled) through C(ModifyDiskAttribute).
+    type: bool
+  performance_level:
+    description:
+      - Performance level for an ESSD disk.
+    choices: ['PL0', 'PL1', 'PL2', 'PL3']
+    type: str
+  provisioned_iops:
+    description:
+      - Provisioned IOPS for a supported disk category.
+    type: int
+  multi_attach:
+    description:
+      - Whether the disk is created as a shared disk. This setting is immutable after creation.
+    type: str
+  delete_auto_snapshot:
+    description:
+      - Whether automatic snapshots are deleted when the disk is deleted.
+      - Applied with C(ModifyDiskAttribute) after disk creation and for an existing disk.
+    type: bool
+  enable_auto_snapshot:
+    description:
+      - Whether automatic snapshots are enabled for the disk.
+      - Applied with C(ModifyDiskAttribute) after disk creation and for an existing disk.
+    type: bool
+  encrypted:
+    description:
+      - Whether to encrypt the disk when it is created.
+      - Disk encryption is immutable after creation.
+    type: bool
+  kms_key_id:
+    description:
+      - Customer-managed KMS key ID used to encrypt the disk.
+      - Requires C(encrypted=true), and must not exceed 64 characters.
+      - The CMK must be a symmetric key in the active state.
+    type: str
   instance_id:
     description:
       - Ecs instance ID is used to attach the disk. The specified instance and disk must be in the same zone.
@@ -113,6 +157,25 @@ EXAMPLES = '''
     description: Create From Ansible
     size: 20
     disk_category: 'cloud'
+    disk_tags:
+      Environment: production
+      CostCenter: R0000000
+    purge_tags: true
+
+# Create an encrypted disk with a customer-managed CMK
+- name: Create encrypted disk
+  alibaba.alicloud.ali_disk:
+    alicloud_zone: cn-beijing-h
+    disk_name: Ansible-Encrypted-Disk
+    size: 20
+    disk_category: cloud_essd
+    encrypted: true
+    kms_key_id: key-xxxxxxxxxxxxxxxx
+    resource_group_id: rg-xxxxxxxx
+    performance_level: PL1
+    multi_attach: Enabled
+    delete_auto_snapshot: true
+    enable_auto_snapshot: false
 
 
 # Example to attach disk to an instance
@@ -158,6 +221,44 @@ disk_status:
     returned: except on delete
     type: str
     sample: "available"
+resource_group_id:
+    description: Resource group ID reported for the disk.
+    returned: when ECS returns a resource group ID
+    type: str
+performance_level:
+    description: Performance level reported for the disk.
+    returned: when ECS returns a performance level
+    type: str
+multi_attach:
+    description: Shared-disk setting reported for the disk.
+    returned: when ECS returns a multi-attach setting
+    type: str
+delete_auto_snapshot:
+    description: Whether automatic snapshots are deleted when the disk is deleted.
+    returned: when ECS returns the setting
+    type: bool
+enable_auto_snapshot:
+    description: Whether automatic snapshots are enabled for the disk.
+    returned: when ECS returns the setting
+    type: bool
+bursting_enabled:
+    description: Whether burst performance is enabled for the disk.
+    returned: when ECS returns the setting
+    type: bool
+provisioned_iops:
+    description: Provisioned IOPS reported for the disk.
+    returned: when ECS returns a provisioned IOPS value
+    type: int
+encrypted:
+    description: Whether the disk is encrypted.
+    returned: except on delete
+    type: bool
+    sample: true
+kms_key_id:
+    description: Customer-managed KMS key ID reported for an encrypted disk.
+    returned: when ECS returns a customer-managed key
+    type: str
+    sample: "key-xxxxxxxxxxxxxxxx"
 disk:
     description: Details about the ecs disk that was created.
     returned: except on delete
@@ -167,9 +268,16 @@ disk:
         "description": "travis-ansible-instance",
         "device": "",
         "disk_name": "travis-ansible-instance",
+        "delete_auto_snapshot": true,
+        "enable_auto_snapshot": false,
+        "encrypted": true,
         "id": "d-2ze9yw0a1sw9neyx8t24",
         "instance_id": "",
         "launch_time": "2017-06-19T03:19:30Z",
+        "kms_key_id": "key-xxxxxxxxxxxxxxxx",
+        "multi_attach": "Enabled",
+        "performance_level": "PL1",
+        "resource_group_id": "rg-xxxxxxxx",
         "region_id": "cn-beijing",
         "size": 40,
         "status": "available",
@@ -217,8 +325,41 @@ def get_disk_detail(disk):
             'description': disk.description,
             'status': disk.status,
             'type': disk.type,
-            'instance_id': disk.instance_id
+            'instance_id': disk.instance_id,
+            'encrypted': getattr(disk, 'encrypted', False),
+            'kms_key_id': getattr(disk, 'kmskey_id', None),
+            'resource_group_id': getattr(disk, 'resource_group_id', None),
+            'performance_level': getattr(disk, 'performance_level', None),
+            'multi_attach': getattr(disk, 'multi_attach', None),
+            'delete_auto_snapshot': getattr(disk, 'delete_auto_snapshot', None),
+            'enable_auto_snapshot': getattr(disk, 'enable_auto_snapshot', None),
+            'bursting_enabled': getattr(disk, 'bursting_enabled', None),
+            'provisioned_iops': getattr(disk, 'provisioned_iops', None)
             }
+
+
+def disk_attribute_matches(disk, parameter, desired):
+    current = getattr(disk, parameter, None)
+    if isinstance(desired, bool) and isinstance(current, str):
+        current = current.lower() == 'true'
+    return current == desired
+
+
+def reconcile_disk_tags(ecs, disk, tags, purge_tags):
+    if not tags and not purge_tags:
+        return False
+    changed = False
+    # Disk.tags in the Footmark version supported by this collection still
+    # parses the legacy TagKey/TagValue spelling. Query the ECS tag API so
+    # reconciliation uses the actual tag set returned by the service.
+    current_tags = ecs.list_tag_resources(resource_ids=[disk.id], resource_type='disk') or {}
+    if purge_tags:
+        remove = {key: value for key, value in current_tags.items() if key not in tags}
+        if remove and ecs.untag_resources(resource_ids=[disk.id], resource_type='disk', tags=remove):
+            changed = True
+    if tags and ecs.tag_resources(resource_ids=[disk.id], resource_type='disk', tags=tags):
+        changed = True
+    return changed
 
 
 def main():
@@ -229,9 +370,18 @@ def main():
         state=dict(type='str', default='present', choices=['present', 'absent']),
         disk_id=dict(type='str', aliases=['vol_id', 'id']),
         disk_name=dict(type='str', aliases=['name']),
-        disk_category=dict(type='str', aliases=['disk_type', 'volume_type'], choices=['cloud', 'cloud_efficiency', 'cloud_ssd', 'cloud_essd'], default='cloud'),
+        disk_category=dict(type='str', aliases=['disk_type', 'volume_type'], choices=['cloud', 'cloud_efficiency', 'cloud_ssd', 'cloud_essd', 'cloud_auto', 'cloud_essd_entry', 'cloud_regional_disk_auto', 'elastic_ephemeral_disk_standard', 'elastic_ephemeral_disk_premium'], default='cloud'),
         size=dict(type='int', aliases=['disk_size', 'volume_size']),
-        disk_tags=dict(type='list', aliases=['tags'], elements='str'),
+        disk_tags=dict(type='dict', aliases=['tags']),
+        purge_tags=dict(type='bool', default=False),
+        bursting_enabled=dict(type='bool', default=None),
+        performance_level=dict(type='str', choices=['PL0', 'PL1', 'PL2', 'PL3']),
+        provisioned_iops=dict(type='int'),
+        multi_attach=dict(type='str'),
+        delete_auto_snapshot=dict(type='bool', default=None),
+        enable_auto_snapshot=dict(type='bool', default=None),
+        encrypted=dict(type='bool', default=False),
+        kms_key_id=dict(type='str'),
         snapshot_id=dict(type='str', aliases=['snapshot']),
         description=dict(type='str', aliases=['disk_description']),
         instance_id=dict(type='str', aliases=['instance']),
@@ -252,6 +402,15 @@ def main():
     disk_name = module.params['disk_name']
     delete_with_instance = module.params['delete_with_instance']
     description = module.params['description']
+    encrypted = module.params['encrypted']
+    kms_key_id = module.params['kms_key_id']
+    disk_tags = module.params['disk_tags'] or {}
+    purge_tags = module.params['purge_tags']
+
+    if kms_key_id and not encrypted:
+        module.fail_json(msg='encrypted must be true when kms_key_id is specified')
+    if kms_key_id and len(kms_key_id) > 64:
+        module.fail_json(msg='kms_key_id must not exceed 64 characters')
 
     changed = False
     current_disk = None
@@ -298,26 +457,79 @@ def main():
     if not current_disk:
         disk_category = module.params['disk_category']
         size = module.params['size']
-        disk_tags = module.params['disk_tags']
         snapshot_id = module.params['snapshot_id']
+        resource_group_id = module.params['resource_group_id']
+        bursting_enabled = module.params['bursting_enabled']
+        performance_level = module.params['performance_level']
+        provisioned_iops = module.params['provisioned_iops']
+        multi_attach = module.params['multi_attach']
+        delete_auto_snapshot = module.params['delete_auto_snapshot']
+        enable_auto_snapshot = module.params['enable_auto_snapshot']
         client_token = "Ansible-Alicloud-%s-%s" % (hash(str(module.params)), str(time.time()))
         try:
-            current_disk = ecs.create_disk(zone_id=zone_id, disk_name=disk_name,
-                                           description=description, disk_category=disk_category, size=size,
-                                           disk_tags=disk_tags, snapshot_id=snapshot_id, client_token=client_token)
+            create_disk_args = dict(zone_id=zone_id, disk_name=disk_name,
+                                    description=description, disk_category=disk_category, size=size,
+                                    snapshot_id=snapshot_id, client_token=client_token)
+            if disk_tags:
+                # Footmark maps ``tags`` to CreateDiskRequest.set_Tags. Passing
+                # the legacy ``disk_tags`` name silently drops the request field.
+                create_disk_args['tags'] = disk_tags
+            if encrypted:
+                create_disk_args['encrypted'] = True
+            if kms_key_id:
+                create_disk_args['kms_key_id'] = kms_key_id
+            if resource_group_id:
+                create_disk_args['resource_group_id'] = resource_group_id
+            if bursting_enabled is not None:
+                create_disk_args['bursting_enabled'] = bursting_enabled
+            if performance_level:
+                create_disk_args['performance_level'] = performance_level
+            if provisioned_iops is not None:
+                create_disk_args['provisioned_iops'] = provisioned_iops
+            if multi_attach:
+                create_disk_args['multi_attach'] = multi_attach
+            current_disk = ecs.create_disk(**create_disk_args)
+            modify_disk_attribute_args = {'disk_id': current_disk.id}
+            for parameter in ('delete_auto_snapshot', 'enable_auto_snapshot'):
+                desired = module.params[parameter]
+                if desired is not None and not disk_attribute_matches(current_disk, parameter, desired):
+                    modify_disk_attribute_args[parameter] = desired
+            if len(modify_disk_attribute_args) > 1:
+                ecs.modify_disk_attribute(**modify_disk_attribute_args)
+                # Footmark's Disk.update() passes the disk ID as the first
+                # positional argument to get_all_volumes(), which is zone_id.
+                # Refresh explicitly by volume_ids to avoid sending
+                # ZoneId=[disk_id] to DescribeDisks.
+                refreshed_disks = ecs.get_all_volumes(volume_ids=[current_disk.id])
+                if refreshed_disks:
+                    current_disk = refreshed_disks[0]
             changed = True
         except Exception as e:
             module.fail_json(msg='Creating a new disk is failed, error: {0}'.format(e))
 
     else:
         try:
-            if current_disk.name != disk_name \
-                    or current_disk.description != description \
-                    or current_disk.delete_with_instance != delete_with_instance:
-                changed = current_disk.modify(disk_name=disk_name, description=description,
-                                              delete_with_instance=delete_with_instance)
+            modify_disk_attribute_args = {'disk_id': current_disk.id}
+            if disk_name and current_disk.name != disk_name:
+                modify_disk_attribute_args['disk_name'] = disk_name
+            if description is not None and current_disk.description != description:
+                modify_disk_attribute_args['description'] = description
+            if current_disk.delete_with_instance != delete_with_instance:
+                modify_disk_attribute_args['delete_with_instance'] = delete_with_instance
+            for parameter in ('delete_auto_snapshot', 'enable_auto_snapshot', 'bursting_enabled'):
+                desired = module.params[parameter]
+                if desired is not None and not disk_attribute_matches(current_disk, parameter, desired):
+                    modify_disk_attribute_args[parameter] = desired
+            if len(modify_disk_attribute_args) > 1:
+                changed = ecs.modify_disk_attribute(**modify_disk_attribute_args)
         except Exception as e:
             module.fail_json(msg='Updating disk {0} attribute is failed, error: {1}'.format(current_disk.id, e))
+
+    try:
+        if reconcile_disk_tags(ecs, current_disk, disk_tags, purge_tags):
+            changed = True
+    except Exception as e:
+        module.fail_json(msg='Updating disk {0} tags failed, error: {1}'.format(current_disk.id, e))
 
     if instance_id and current_disk and str(current_disk.status).lower() == "available":
         try:
@@ -327,7 +539,17 @@ def main():
                 msg='Attaching disk {0} to instance {1} is failed, error: {2}'.format(current_disk.id, instance_id, e))
 
     module.exit_json(changed=changed, disk_id=current_disk.id, disk_category=current_disk.category,
-                     disk_status=current_disk.status, instance_id=instance_id, disk=get_disk_detail(current_disk))
+                     disk_status=current_disk.status, instance_id=instance_id,
+                     encrypted=getattr(current_disk, 'encrypted', False),
+                     kms_key_id=getattr(current_disk, 'kmskey_id', None),
+                     resource_group_id=getattr(current_disk, 'resource_group_id', None),
+                     performance_level=getattr(current_disk, 'performance_level', None),
+                     multi_attach=getattr(current_disk, 'multi_attach', None),
+                     delete_auto_snapshot=getattr(current_disk, 'delete_auto_snapshot', None),
+                     enable_auto_snapshot=getattr(current_disk, 'enable_auto_snapshot', None),
+                     bursting_enabled=getattr(current_disk, 'bursting_enabled', None),
+                     provisioned_iops=getattr(current_disk, 'provisioned_iops', None),
+                     disk=get_disk_detail(current_disk))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ali_disk_info.py
+++ b/plugins/modules/ali_disk_info.py
@@ -184,14 +184,15 @@ def main():
     for disk in ecs.describe_disks(**filters):
         if name_prefix and not str(disk.name).startswith(name_prefix):
             continue
-        if tags:
-            flag = False
-            for key, value in list(tags.items()):
-                if key in list(disk.tags.keys()) and value == disk.tags[key]:
-                    flag = True
-            if not flag:
-                continue
-        disks.append(disk.read())
+        # Footmark's Disk parser reads the legacy TagKey/TagValue spelling,
+        # while current ECS responses are normalized to tag_key/tag_value.
+        # Fetch tags from ListTagResources so callers receive the real set.
+        disk_tags = ecs.list_tag_resources(resource_ids=[disk.id], resource_type='disk') or {}
+        if tags and not all(disk_tags.get(key) == value for key, value in tags.items()):
+            continue
+        disk_detail = disk.read()
+        disk_detail['tags'] = disk_tags
+        disks.append(disk_detail)
         disk_ids.append(disk.id)
 
     module.exit_json(changed=False, disk_ids=disk_ids, disks=disks, total=len(disks))

--- a/plugins/tests/ali_disk_test.yml
+++ b/plugins/tests/ali_disk_test.yml
@@ -1,0 +1,312 @@
+---
+- name: Validate module ali_disk
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  environment:
+    ALICLOUD_REGION: '{{ disk_test_region }}'
+
+  vars:
+    disk_test_region: "{{ lookup('ansible.builtin.env', 'ALICLOUD_TEST_REGION') | default('cn-beijing', true) }}"
+    disk_test_zone: "{{ lookup('ansible.builtin.env', 'ALICLOUD_TEST_ZONE') | default('cn-beijing-f', true) }}"
+    disk_test_name: "ansible-testacc-ali-disk-encrypted-{{ lookup('pipe', 'date +%s') }}"
+    essd_disk_test_name: "ansible-testacc-ali-disk-essd-{{ lookup('pipe', 'date +%s') }}"
+    essd_entry_disk_test_name: "ansible-testacc-ali-disk-essd-entry-{{ lookup('pipe', 'date +%s') }}"
+    regional_disk_test_name: "ansible-testacc-ali-disk-regional-{{ lookup('pipe', 'date +%s') }}"
+    autopl_disk_test_name: "ansible-testacc-ali-disk-autopl-{{ lookup('pipe', 'date +%s') }}"
+    test_kms_key_id: "{{ lookup('ansible.builtin.env', 'ALICLOUD_TEST_KMS_KEY_ID') }}"
+    test_resource_group_id: "{{ lookup('ansible.builtin.env', 'ALICLOUD_TEST_RESOURCE_GROUP_ID') }}"
+    initial_disk_tags:
+      ManagedBy: ansible
+      Legacy: remove
+    reconciled_disk_tags:
+      ManagedBy: ansible
+      Environment: test
+
+  tasks:
+    - name: Require the disk feature test inputs
+      ansible.builtin.assert:
+        that:
+          - test_kms_key_id | length > 0
+          - test_resource_group_id | length > 0
+        fail_msg: >-
+          ALICLOUD_TEST_KMS_KEY_ID and ALICLOUD_TEST_RESOURCE_GROUP_ID are required
+          for the ali_disk feature test.
+
+    - block:
+        - name: Reject a KMS key without disk encryption
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: 'ansible-invalid-kms-{{ lookup("pipe", "date +%s") }}'
+            size: 20
+            kms_key_id: '{{ test_kms_key_id }}'
+          register: kms_without_encryption
+          failed_when: false
+
+        - name: Assert a KMS key requires disk encryption
+          ansible.builtin.assert:
+            that:
+              - "'encrypted must be true' in kms_without_encryption.msg"
+
+        - name: Reject an overlong KMS key ID
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: 'ansible-invalid-kms-length-{{ lookup("pipe", "date +%s") }}'
+            size: 20
+            encrypted: true
+            kms_key_id: '{{ "x" * 65 }}'
+          register: overlong_kms_key
+          failed_when: false
+
+        - name: Assert the KMS key ID length is validated
+          ansible.builtin.assert:
+            that:
+              - "'kms_key_id must not exceed 64 characters' in overlong_kms_key.msg"
+
+        - name: Create an encrypted efficient disk with a customer-managed CMK
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: '{{ disk_test_name }}'
+            description: 'Validate ali_disk creation capabilities'
+            size: 20
+            disk_category: cloud_efficiency
+            encrypted: true
+            kms_key_id: '{{ test_kms_key_id }}'
+            resource_group_id: '{{ test_resource_group_id }}'
+            delete_auto_snapshot: true
+            enable_auto_snapshot: false
+            disk_tags: '{{ initial_disk_tags }}'
+            purge_tags: true
+          register: created_disk
+
+        - name: Read the encrypted efficient disk
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_disk.disk_id }}'
+          register: disk_info
+
+        - name: Assert encrypted efficient disk creation capabilities
+          ansible.builtin.assert:
+            that:
+              - created_disk.encrypted | bool
+              - created_disk.kms_key_id == test_kms_key_id
+              - created_disk.resource_group_id == test_resource_group_id
+              - created_disk.delete_auto_snapshot | bool
+              - not (created_disk.enable_auto_snapshot | bool)
+              - disk_info.total | int == 1
+              - disk_info.disks[0].encrypted | bool
+              - disk_info.disks[0].kmskey_id == test_kms_key_id
+              - disk_info.disks[0].resource_group_id == test_resource_group_id
+              - disk_info.disks[0].delete_auto_snapshot | bool
+              - not (disk_info.disks[0].enable_auto_snapshot | bool)
+              - disk_info.disks[0].tags.ManagedBy == initial_disk_tags.ManagedBy
+              - disk_info.disks[0].tags.Legacy == initial_disk_tags.Legacy
+
+        - name: Filter the disk by all declared tags
+          ali_disk_info:
+            tags: '{{ initial_disk_tags }}'
+          register: tagged_disk_info
+
+        - name: Assert tag filtering finds the created disk
+          ansible.builtin.assert:
+            that:
+              - created_disk.disk_id in tagged_disk_info.disk_ids
+
+        - name: Update automatic snapshot attributes on the existing efficient disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_disk.disk_id }}'
+            delete_auto_snapshot: false
+            enable_auto_snapshot: true
+          register: updated_disk
+
+        - name: Read the efficient disk after updating automatic snapshot attributes
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_disk.disk_id }}'
+          register: updated_disk_info
+
+        - name: Assert automatic snapshot attributes were updated
+          ansible.builtin.assert:
+            that:
+              - updated_disk.changed | bool
+              - not (updated_disk_info.disks[0].delete_auto_snapshot | bool)
+              - updated_disk_info.disks[0].enable_auto_snapshot | bool
+
+        - name: Reconcile tags on the existing efficient disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_disk.disk_id }}'
+            disk_tags: '{{ reconciled_disk_tags }}'
+            purge_tags: true
+          register: reconciled_disk
+
+        - name: Read the efficient disk after reconciling tags
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_disk.disk_id }}'
+          register: reconciled_disk_info
+
+        - name: Assert efficient disk tags match the declared set
+          ansible.builtin.assert:
+            that:
+              - reconciled_disk.changed | bool
+              - reconciled_disk_info.disks[0].tags.ManagedBy == reconciled_disk_tags.ManagedBy
+              - reconciled_disk_info.disks[0].tags.Environment == reconciled_disk_tags.Environment
+              - "'Legacy' not in reconciled_disk_info.disks[0].tags"
+
+        - name: Create an ESSD with an explicit performance level
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: '{{ essd_disk_test_name }}'
+            description: 'Validate ali_disk ESSD performance level during creation'
+            size: 20
+            disk_category: cloud_essd
+            performance_level: PL1
+            resource_group_id: '{{ test_resource_group_id }}'
+          register: created_essd_disk
+
+        - name: Read the ESSD disk
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_essd_disk.disk_id }}'
+          register: essd_disk_info
+
+        - name: Assert the ESSD performance level was applied
+          ansible.builtin.assert:
+            that:
+              - essd_disk_info.total | int == 1
+              - essd_disk_info.disks[0].category == 'cloud_essd'
+              - essd_disk_info.disks[0].performance_level == 'PL1'
+
+        - name: Create an ESSD Entry disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: '{{ essd_entry_disk_test_name }}'
+            description: 'Validate ali_disk ESSD Entry category during creation'
+            size: 20
+            disk_category: cloud_essd_entry
+            resource_group_id: '{{ test_resource_group_id }}'
+          register: created_essd_entry_disk
+
+        - name: Read the ESSD Entry disk
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_essd_entry_disk.disk_id }}'
+          register: essd_entry_disk_info
+
+        - name: Assert the ESSD Entry category was applied
+          ansible.builtin.assert:
+            that:
+              - essd_entry_disk_info.total | int == 1
+              - essd_entry_disk_info.disks[0].category == 'cloud_essd_entry'
+
+        - name: Create an ESSD regional disk without a zone
+          ali_disk:
+            disk_name: '{{ regional_disk_test_name }}'
+            description: 'Validate ali_disk ESSD regional category during creation'
+            size: 20
+            disk_category: cloud_regional_disk_auto
+            resource_group_id: '{{ test_resource_group_id }}'
+          register: created_regional_disk
+
+        - name: Read the ESSD regional disk
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_regional_disk.disk_id }}'
+          register: regional_disk_info
+
+        - name: Assert the ESSD regional category was applied
+          ansible.builtin.assert:
+            that:
+              - regional_disk_info.total | int == 1
+              - regional_disk_info.disks[0].category == 'cloud_regional_disk_auto'
+
+        - name: Create an ESSD AutoPL disk with burst performance
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_name: '{{ autopl_disk_test_name }}'
+            description: 'Validate ali_disk AutoPL settings during creation'
+            size: 20
+            disk_category: cloud_auto
+            bursting_enabled: false
+            provisioned_iops: 100
+            resource_group_id: '{{ test_resource_group_id }}'
+          register: created_autopl_disk
+
+        - name: Read the AutoPL disk
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_autopl_disk.disk_id }}'
+          register: autopl_disk_info
+
+        - name: Assert burst performance and provisioned IOPS were applied
+          ansible.builtin.assert:
+            that:
+              - autopl_disk_info.total | int == 1
+              - autopl_disk_info.disks[0].category == 'cloud_auto'
+              - not (autopl_disk_info.disks[0].bursting_enabled | bool)
+              - autopl_disk_info.disks[0].provisioned_iops | int == 100
+              - autopl_disk_info.disks[0].resource_group_id == test_resource_group_id
+
+        - name: Enable burst performance on the existing AutoPL disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_autopl_disk.disk_id }}'
+            bursting_enabled: true
+          register: updated_autopl_disk
+
+        - name: Read the AutoPL disk after enabling burst performance
+          ali_disk_info:
+            filters:
+              disk_ids:
+                - '{{ created_autopl_disk.disk_id }}'
+          register: updated_autopl_disk_info
+
+        - name: Assert burst performance was updated
+          ansible.builtin.assert:
+            that:
+              - updated_autopl_disk.changed | bool
+              - updated_autopl_disk_info.disks[0].bursting_enabled | bool
+
+      always:
+        - name: Delete the AutoPL test disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_autopl_disk.disk_id }}'
+            state: absent
+          when: created_autopl_disk is defined and created_autopl_disk.disk_id is defined
+
+        - name: Delete the ESSD Entry test disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_essd_entry_disk.disk_id }}'
+            state: absent
+          when: created_essd_entry_disk is defined and created_essd_entry_disk.disk_id is defined
+
+        - name: Delete the ESSD regional test disk
+          ali_disk:
+            disk_id: '{{ created_regional_disk.disk_id }}'
+            state: absent
+          when: created_regional_disk is defined and created_regional_disk.disk_id is defined
+
+        - name: Delete the ESSD test disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_essd_disk.disk_id }}'
+            state: absent
+          when: created_essd_disk is defined and created_essd_disk.disk_id is defined
+
+        - name: Delete the encrypted efficient test disk
+          ali_disk:
+            alicloud_zone: '{{ disk_test_zone }}'
+            disk_id: '{{ created_disk.disk_id }}'
+            state: absent
+          when: created_disk is defined and created_disk.disk_id is defined

--- a/plugins/tests/group_vars/all
+++ b/plugins/tests/group_vars/all
@@ -75,7 +75,9 @@ disk_name: "Disk_From_Ansible"
 disk_category: "cloud_ssd"
 disk_description: "Create a new ECS disk resource via Ansible example alicloud-ecs-vpc."
 data_disk_size: 80
-disk_tags: [{tag_key: "created_by", tag_value: "Ansible-Alicloud"}, {tag_key: "created_from", tag_value: "example-alicloud-ecs-vpc"}]
+disk_tags:
+  created_by: "Ansible-Alicloud"
+  created_from: "example-alicloud-ecs-vpc"
 delete_with_instance: True
 
 delete: False


### PR DESCRIPTION
## Summary
- accept disk_tags as a YAML mapping
- map disk tags to the CreateDisk Tags request field
- update module examples and integration test variables

## Validation
- git diff --check
- Python syntax compilation
- ansible-doc schema validation
- Footmark CreateDisk set_Tags mapping assertion

Aone work item: https://project.aone.alibaba-inc.com/coco/projects/1086837/workitems/85798807