### PR TITLE
chore: bump collection version to 1.2.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: alibaba
 name: alicloud
-version: 1.1.1
+version: 1.2.0
 readme: README.md
 authors:
 - He Guimin (@xiaozhu36)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,6 +5,7 @@ readme: README.md
 authors:
 - He Guimin (@xiaozhu36)
 - Li Xue (@lixue323)
+- Xu Ziqi (@shanye997)
 description: Alibaba Cloud
 license:
 - GPL-3.0-or-later


### PR DESCRIPTION
## Summary

- Bump the Alibaba Cloud collection version from `1.1.1` to `1.2.0`.
- The disk management feature set is already present in the current `master`; this PR contains only the release-version update.

## Validation

- `git diff --check`